### PR TITLE
Coverage badge link fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**0.4.2**
+- Fixed the link to the coveralls report being set on branch development instead of master in the documentation.
+- Added a link to the Travis CI report for the Travis CI badge in the documentation.
+
 **0.4.1**
 - Added Travis CI logo in the corresponding badge.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # command-parser
 
-[![](https://img.shields.io/github/license/aminnairi/command-parser.svg?style=square&logo=github)](./LICENSE) [![](https://img.shields.io/npm/v/@aminnairi/command-parser.svg?style=square&logo=npm)](https://www.npmjs.com/package/@aminnairi/command-parser)  ![](https://img.shields.io/david/aminnairi/command-parser.svg?logo=npm) ![](https://img.shields.io/snyk/vulnerabilities/npm/@aminnairi/command-parser.svg?logo=npm) [![Coverage Status](https://coveralls.io/repos/github/aminnairi/command-parser/badge.svg?branch=master)](https://coveralls.io/github/aminnairi/command-parser?branch=development) ![](https://img.shields.io/travis/aminnairi/command-parser/master.svg?logo=travis)
+[![](https://img.shields.io/github/license/aminnairi/command-parser.svg?style=square&logo=github)](./LICENSE) [![](https://img.shields.io/npm/v/@aminnairi/command-parser.svg?style=square&logo=npm)](https://www.npmjs.com/package/@aminnairi/command-parser)  ![](https://img.shields.io/david/aminnairi/command-parser.svg?logo=npm) ![](https://img.shields.io/snyk/vulnerabilities/npm/@aminnairi/command-parser.svg?logo=npm) [![](https://img.shields.io/travis/aminnairi/command-parser/master.svg?logo=travis)](https://travis-ci.org/aminnairi/command-parser) [![](https://img.shields.io/coveralls/github/aminnairi/command-parser/master.svg)](https://coveralls.io/github/aminnairi/command-parser?branch=master)
 
 Command Line Arguments Parser
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@aminnairi/command-parser",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aminnairi/command-parser",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Command Line Parser",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Fix #5 

## Changelog

- [x] Fixed the link to the coveralls report being set on branch development instead of master in the documentation.
- [x] Added a link to the Travis CI report for the Travis CI badge in the documentation.
